### PR TITLE
change infrastructure to use existing comint components

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,10 +141,10 @@ Here is a slightly modified version of the authors current configuration for com
 
 ```
 (use-package comint-histories
+  :custom
+  (comint-histories-global-filters '((lambda (x) (<= (length x) 3)) string-blank-p))
   :config
   (comint-histories-mode 1)
-
-  (setq comint-histories-global-filters '((lambda (x) (<= (length x) 3))))
 
   (comint-histories-add-history gdb
     :predicates '((lambda () (string-match-p "^(gdb)" (comint-histories-get-prompt))))

--- a/README.md
+++ b/README.md
@@ -127,10 +127,6 @@ A list of global filters to be used as a filter for every history. Here is an ex
 
 Directory to place history files for persistent histories.
 
-#### comint-histories-set-comint-input
-
-Sets `comint-input-ring` based on relevant saved histories.
-
 ## Example configuration
 
 Here is a slightly modified version of my current configuration for comint-histories:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ comint-histories allows you to to create separate histories for different comint
 
 Say, for example, you use `M-x shell` as your shell, but you also use `M-x shell` to run python repls and use gdb. You could have three histories, one for shell inputs, one for python inputs, and another for gdb inputs. Each of these histories could have different lengths and policies for what input is allowed in the history. You may also sometimes run your python repl from its inferior-mode (`M-x run-python`), and you want those inputs added to the same python history as when you run python through `M-x shell`. This is all possible with comint-histories.
 
+For the most part comint-histories leverages the existing components of comint-mode, including the `comint-input-ring`.
+
 To use comint-histories you must turn on the global minor mode `comint-histories-mode`:
 
 ```
@@ -56,6 +58,10 @@ Usage: (comint-histories-add-history history-name
 
 :length        Maximum length of the history ring. Defaults to 100.
 
+:no-dups       Do not allow duplicate entries from entering the history. When
+               adding a duplicate item to the history, the older entry is
+               removed first. Defaults to NIL.
+
 :rtrim         If non-nil, then trim beginning whitespace from the input before
                adding attempting to add it to the history. Defaults to T.
 
@@ -80,6 +86,8 @@ length if :length was changed in PROPS."
 #### comint-histories-search-history
 
 This is the only interactive function provided by comint-histories and allows you to browse a history with `completing-read` to select and insert a history item. If called with prefix arg, then the user is prompted to select a history with `completing-read`, otherwise automatic selection is made.
+
+Though comint-histories leverages the `comint-input-ring`, which means functions like `comint-history-isearch-backward` work seamlessly, a `completing-read` interface is preferred by the author of comint-histories.
 
 Many packages will sort the candidates for `completing-read`, however, you almost certainly do not want your histories sorted as they are already in order of newest entries to oldest. For this reason, a binding similar to the following is recommended for using `comint-histories-search-history`.
 
@@ -129,7 +137,7 @@ Directory to place history files for persistent histories.
 
 ## Example configuration
 
-Here is a slightly modified version of my current configuration for comint-histories:
+Here is a slightly modified version of the authors current configuration for comint-histories:
 
 ```
 (use-package comint-histories
@@ -140,7 +148,8 @@ Here is a slightly modified version of my current configuration for comint-histo
 
   (comint-histories-add-history gdb
     :predicates '((lambda () (string-match-p "^(gdb)" (comint-histories-get-prompt))))
-    :length 2000)
+    :length 2000
+    :no-dups t)
 
   (comint-histories-add-history python
     :predicates '((lambda () (or (derived-mode-p 'inferior-python-mode)
@@ -149,12 +158,14 @@ Here is a slightly modified version of my current configuration for comint-histo
 
   (comint-histories-add-history ielm
     :predicates '((lambda () (derived-mode-p 'inferior-emacs-lisp-mode)))
-    :length 2000)
+    :length 2000
+    :no-dups t)
 
   (comint-histories-add-history shell
     :predicates '((lambda () (derived-mode-p 'shell-mode)))
     :filters '("^ls" "^cd")
-    :length 2000)
+    :length 2000
+    :no-dups t)
 
   (define-key comint-mode-map (kbd "C-r") #'(lambda () (interactive)
                                               (let ((ivy-sort-functions-alist nil)

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ A list of global filters to be used as a filter for every history. Here is an ex
 
 Directory to place history files for persistent histories.
 
+#### comint-histories-set-comint-input
+
+Sets `comint-input-ring` based on relevant saved histories.
+
 ## Example configuration
 
 Here is a slightly modified version of my current configuration for comint-histories:

--- a/comint-histories.el
+++ b/comint-histories.el
@@ -236,6 +236,8 @@ to that histories history ring."
                            (car comint-histories--last-selected-history))))
       (setq-local comint-histories--last-selected-history selected-history)
       (setq-local comint-input-ring (plist-get (cdr selected-history) :history))
+      (setq-local comint-input-ring-size
+                  (plist-get (cdr selected-history :length)))
       (setq-local comint-input-filter
                   (comint-histories--history-filter-function selected-history)))
     selected-history))

--- a/comint-histories.el
+++ b/comint-histories.el
@@ -274,9 +274,6 @@ Note that indices start at 0."
 
 (defun comint-histories--save-histories-to-disk ()
   "Save persistent histories in `comint-histories--histories' to disk."
-  (dolist (buf (buffer-list))
-    (with-current-buffer buf
-      (when (derived-mode-p 'comint-mode))))
   (dolist (history comint-histories--histories)
     (when (plist-get (cdr history) :persist)
       (comint-histories--save-history-to-disk history))))

--- a/comint-histories.el
+++ b/comint-histories.el
@@ -43,10 +43,6 @@
 (defvar comint-histories--histories nil
   "Internal alist of plists containing all defined histories.")
 
-(defgroup comint-histories nil
-  "Persist multiple comint histories across different processes."
-  :group 'convenience)
-
 (defmacro comint-histories-add-history (name &rest props)
   "Declare a comint-histories history named NAME with properties PROPS.
 

--- a/comint-histories.el
+++ b/comint-histories.el
@@ -220,7 +220,11 @@ If INSERT is non-nil then insert the history into HISTORY's history ring."
   "Select a history from `comint-histories--histories'.
 
 A history is selected if all of it's :predicates return non-nil when invoked
-with zero arguments."
+with zero arguments. If a history is selected that is different than
+`comint-histories--last-selected-history', then save back `comint-input-ring' to
+`comint-histories--last-selected-history's :history entry in the history list,
+and set the newly selected histories :history as `comint-input-ring', and update
+`comint-histories--last-selected-history'."
   (let ((selected-history))
     (catch 'loop
       (dolist (history comint-histories--histories)
@@ -309,8 +313,9 @@ when `comint-histories-mode' is enabled."
 
 (defun comint-histories--comint-mode-hook ()
   "Hook to `comint-mode-hook' used when `comint-histories-mode' is on."
-  (setq-local comint-input-ring (make-ring comint-input-ring-size))
-  (setq-local comint-input-filter comint-input-filter))
+  (unless (comint-histories--select-history)
+    (setq-local comint-input-ring (make-ring comint-input-ring-size))
+    (setq-local comint-input-filter comint-input-filter)))
 
 (define-minor-mode comint-histories-mode
   "Toggle `comint-histories-mode'."

--- a/comint-histories.el
+++ b/comint-histories.el
@@ -43,8 +43,14 @@
 (defvar comint-histories--histories nil
   "Internal alist of plists containing all defined histories.")
 
+(defgroup comint-histories nil
+  "Persist multiple comint histories across different processes."
+  :group 'convenience)
+
 (defcustom comint-histories-set-comint-input nil
-  "If non-nil set `comint-input-ring' in a new comint buffer from an appropriate comint history.")
+  "If non-nil set `comint-input-ring' in a new comint buffer from an appropriate comint history."
+  :group 'comint-histories
+  :type 'boolean)
 
 (defmacro comint-histories-add-history (name &rest props)
   "Declare a comint-histories history named NAME with properties PROPS.

--- a/comint-histories.el
+++ b/comint-histories.el
@@ -208,7 +208,7 @@ If INSERT is non-nil then insert the history into HISTORY's history ring."
       (setq text (concat text (format "%s%c" x #x1F))))
     (f-write-text text 'utf-8 history-file)))
 
-(defun comint-histories--select-history ()
+(defun comint-histories--select-history (&rest _args)
   "Select a history from `comint-histories--histories'.
 
 A history is selected if all of it's :predicates return non-nil when invoked
@@ -285,13 +285,13 @@ This function is used as :filter-args advice to `comint-add-to-input-history'
 when `comint-histories-mode' is enabled."
   (if-let ((history comint-histories--last-selected-history))
       (let ((ltrim (plist-get (cdr history) :ltrim))
-            (rtrim (plist-get (cdr history) :rtrim))
-            (cmd (car args)))
-        (when ltrim
-          (setq cmd (replace-regexp-in-string "^[\n\r ]+" "" cmd)))
-        (when rtrim
-          (setq cmd (replace-regexp-in-string "[\n\r ]+$" "" cmd)))
-        (list cmd))
+            (rtrim (plist-get (cdr history) :rtrim)))
+        (when-let ((cmd (car args)))
+          (when ltrim
+            (setq cmd (replace-regexp-in-string "^[\n\r ]+" "" cmd)))
+          (when rtrim
+            (setq cmd (replace-regexp-in-string "[\n\r ]+$" "" cmd)))
+          (list cmd)))
     args))
 
 (defun comint-histories--comint-mode-hook ()

--- a/comint-histories.el
+++ b/comint-histories.el
@@ -202,7 +202,8 @@ If INSERT is non-nil then insert the history into HISTORY's history ring."
     (when insert
       (let ((comint-input-ring (plist-get (cdr history) :history))
             (comint-input-filter
-             (comint-histories--history-filter-function history)))
+             (comint-histories--history-filter-function history))
+            (comint-input-ring-size (plist-get (cdr history) :length)))
         (dolist (x (reverse lines))
           (comint-add-to-input-history x))))
     lines))
@@ -212,9 +213,11 @@ If INSERT is non-nil then insert the history into HISTORY's history ring."
   (let* ((history-file (comint-histories--history-file history))
          (existing-history (ring-elements (plist-get (cdr history) :history)))
          (loaded-history (comint-histories--load-history-from-disk history))
+         (all-history (append existing-history loaded-history))
          (text ""))
-    (dolist (x (seq-take (delete-dups (append existing-history loaded-history))
-                         (plist-get (cdr history) :length)))
+    (when (plist-get (cdr history) :no-dups)
+      (setq all-history (delete-dups all-history)))
+    (dolist (x (seq-take all-history (plist-get (cdr history) :length)))
       (setq text (concat text (format "%s%c" x #x1F))))
     (f-write-text text 'utf-8 history-file)))
 

--- a/comint-histories.el
+++ b/comint-histories.el
@@ -43,6 +43,9 @@
 (defvar comint-histories--histories nil
   "Internal alist of plists containing all defined histories.")
 
+(defcustom comint-histories-set-comint-input nil
+  "If non-nil set `comint-input-ring' in a new comint buffer from an appropriate comint history.")
+
 (defmacro comint-histories-add-history (name &rest props)
   "Declare a comint-histories history named NAME with properties PROPS.
 
@@ -285,6 +288,14 @@ This function is used as advice aroung `comint-send-input' when
   (dolist (history comint-histories--histories)
     (when (plist-get (cdr history) :persist)
       (comint-histories--save-history history))))
+
+(defun comint-histories--comint-mode-hook ()
+  "Run comint-histories `comint-mode' configuration."
+  (when comint-histories-set-comint-input
+    (setq comint-input-ring
+          (plist-get (cdr (comint-histories--select-history)) :history))))
+
+(add-hook 'comint-mode-hook comint-histories--comint-mode-hook)
 
 (define-minor-mode comint-histories-mode
   "Toggle `comint-histories-mode'."

--- a/comint-histories.el
+++ b/comint-histories.el
@@ -237,7 +237,7 @@ to that histories history ring."
       (setq-local comint-histories--last-selected-history selected-history)
       (setq-local comint-input-ring (plist-get (cdr selected-history) :history))
       (setq-local comint-input-ring-size
-                  (plist-get (cdr selected-history :length)))
+                  (plist-get (cdr selected-history) :length))
       (setq-local comint-input-filter
                   (comint-histories--history-filter-function selected-history)))
     selected-history))

--- a/comint-histories.el
+++ b/comint-histories.el
@@ -33,12 +33,16 @@
 (require 'seq)
 (require 'f)
 
-(defvar comint-histories-persist-dir
+(defcustom comint-histories-persist-dir
   (f-join user-emacs-directory "comint-histories")
-  "Directory for storing saved histories.")
+  "Directory for storing saved histories."
+  :type 'string
+  :group 'comint-histories)
 
-(defvar comint-histories-global-filters nil
-  "Filters to be implicitly added to all history :filters.")
+(defcustom comint-histories-global-filters nil
+  "Filters to be implicitly added to all history :filters."
+  :type '(repeat sexp)
+  :group 'comint-histories)
 
 (defvar-local comint-histories--last-selected-history nil
   "Internal variable to keep track of the buffers selected history.")

--- a/comint-histories.el
+++ b/comint-histories.el
@@ -1,4 +1,4 @@
-;;; comint-histories.el --- Many comint histories  -*- lexical-binding: t; -*-
+;;; comint-histories.el --- Many comint histories -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2025 Nicholas Hubbard <nicholashubbard@posteo.net>
 ;;
@@ -9,7 +9,7 @@
 ;; Author: Nicholas Hubbard <nicholashubbard@posteo.net>
 ;; URL: https://github.com/NicholasBHubbard/comint-histories
 ;; Package-Requires: ((emacs "25.1") (f "0.21.0"))
-;; Version: 1.3
+;; Version: 1.4
 ;; Created: 2025-01-02
 ;; By: Nicholas Hubbard <nicholashubbard@posteo.net>
 ;; Keywords: convenience, processes, terminals
@@ -51,27 +51,29 @@ Usage: (comint-histories-add-history history-name
 
 :predicates             List of functions that take zero args who's conjunction
                         determines the selection of this history.
-                        
-:filters                List of regexp strings and functions that take one arg.  If the
-                        input matches any of the regexp's, or any of the functions return
-                        non-nil when applied to the input, then the input is not added
-                        to the history.
-                        
-:persist                If non-nil, then save and load the history to/from a file.
-                        Defaults to T.
-                        
+
+:filters                List of regexp strings and functions that take one arg.
+                        If the input matches any of the regexp's, or any of the
+                        functions return non-nil when applied to the input, then
+                        the input is not added to the history.
+
+:persist                If non-nil, then save and load the history to/from a
+                        file. Defaults to T.
+
 :length                 Maximum length of the history ring. Defaults to 100.
-                        
-:rtrim                  If non-nil, then trim beginning whitespace from the input before
-                        adding attempting to add it to the history. Defaults to T.
-                        
-:ltrim                  If non-nil, then trim ending whitespace from the input before
-                        attempting to add it to the history. Defaults to T. 
-                        
-:set-comint-input-ring  If non-nil set `comint-input-ring' in matching comint buffers to this
-                        history's ring, and set `comint-input-filter' using :predicates if
-                        specified.
-                        
+
+:rtrim                  If non-nil, then trim beginning whitespace from the
+                        input before adding attempting to add it to the history.
+                        Defaults to T.
+
+:ltrim                  If non-nil, then trim ending whitespace from the input
+                        before attempting to add it to the history. Defaults to
+                        T.
+
+:set-comint-input-ring  If non-nil, set `comint-input-ring' in matching comint
+                        buffers to this history's ring, and set
+                        `comint-input-filter' using :filters if specified.
+                        Defaults to NIL.
 
 If a history with name NAME does not already exist in
 `comint-histories--histories', then the new one will be added to the end of
@@ -127,7 +129,7 @@ length if :length was changed in PROPS."
 (defun comint-histories-search-history (arg &optional history)
   "Search the HISTORY with `completing-read' and insert the selection.
 
-If HISTORY is NIL then if ARG (or prefix arg) prompt for a history else
+If HISTORY is NIL, then if ARG (or prefix arg) prompt for a history, else
 automatically select the history."
   (interactive "P")
   (let ((history (or history
@@ -225,7 +227,10 @@ history."
   "Select a history from `comint-histories--histories'.
 
 A history is selected if all of it's :predicates return non-nil when invoked
-with zero arguments."
+with zero arguments.
+
+If the selected history has non-nil :set-comint-input-ring, then invokes
+`comint-histories--setup-comint-input-ring' applied to the selected history."
   (let ((selected-history))
     (catch 'loop
       (dolist (history comint-histories--histories)
@@ -280,7 +285,7 @@ Note that indices start at 0."
 (defun comint-histories--process-comint-input (&rest _)
   "Process the current comint input buffer, potentially adding it to a history.
 
-This function is used as advice aroung `comint-send-input' when
+This function is used as advice around `comint-send-input' when
 `comint-histories-mode' is enabled."
   (when-let ((history (comint-histories--select-history)))
     (let ((input (comint-histories-get-input)))

--- a/comint-histories.el
+++ b/comint-histories.el
@@ -301,8 +301,6 @@ This function is used as advice aroung `comint-send-input' when
     (setq comint-input-ring
           (plist-get (cdr (comint-histories--select-history)) :history))))
 
-(add-hook 'comint-mode-hook comint-histories--comint-mode-hook)
-
 (define-minor-mode comint-histories-mode
   "Toggle `comint-histories-mode'."
   :global t
@@ -312,7 +310,8 @@ This function is used as advice aroung `comint-send-input' when
       (progn
         (advice-add 'comint-send-input :before
                     #'comint-histories--process-comint-input)
-        (add-hook 'kill-emacs-hook #'comint-histories--save-histories))
+        (add-hook 'kill-emacs-hook #'comint-histories--save-histories)
+        (add-hook 'comint-mode-hook #'comint-histories--comint-mode-hook))
     (advice-remove 'comint-send-input #'comint-histories--process-comint-input)
     (remove-hook 'kill-emacs-hook #'comint-histories--save-histories)))
 


### PR DESCRIPTION
Hi!  I was looking for a way for histories I have configured to be respected by existing `comint` commands, for example `M-p`, `M-n`, etc.

Surprisingly, all I needed to do was hook in when comint mode was started and set `comint-input-ring` based on a relevant history.